### PR TITLE
Check code visibility

### DIFF
--- a/src/main/java/frc/robot/common/commands/DriveCommands.java
+++ b/src/main/java/frc/robot/common/commands/DriveCommands.java
@@ -87,9 +87,11 @@ public class DriveCommands {
                             omega * drive.getMaxAngularSpeedRadPerSec());
                     boolean isFlipped = DriverStation.getAlliance().isPresent()
                             && DriverStation.getAlliance().get() == Alliance.Red;
-                    speeds = ChassisSpeeds.fromRobotRelativeSpeeds(
+                    speeds = ChassisSpeeds.fromFieldRelativeSpeeds(
                             speeds,
-                            isFlipped ? drive.getRotation() : drive.getRotation());
+                            isFlipped
+                                    ? drive.getRotation().plus(new Rotation2d(Math.PI))
+                                    : drive.getRotation());
                             //System.out.println("isFlipped is " + isFlipped);
                     drive.runVelocity(speeds);
                 },


### PR DESCRIPTION
Change joystick drive transform to field-relative to fix robot drifting when driving straight forward/backward.

The original `fromRobotRelativeSpeeds` incorrectly rotated the joystick command, causing unintended strafe/rotation instead of straight-line motion. Switching to `fromFieldRelativeSpeeds` with proper alliance flip ensures accurate translation relative to the field.

---
<a href="https://cursor.com/background-agent?bcId=bc-05955d9e-6c0a-46fe-bea1-edd73abc32ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-05955d9e-6c0a-46fe-bea1-edd73abc32ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

