### PR TITLE
Diagnose robot leftward drive drift

### DIFF
--- a/src/main/java/frc/robot/common/subsystems/drive/ModuleIOSpark.java
+++ b/src/main/java/frc/robot/common/subsystems/drive/ModuleIOSpark.java
@@ -95,9 +95,10 @@ public class ModuleIOSpark implements ModuleIO {
         turnController = turnSpark.getClosedLoopController();
 
         configureCANcoder();
-        initializeTurnOffset();
-        configureDriveMotor();
+        // Configure conversion factors BEFORE setting the initial position so setPosition uses radians
         configureTurnMotor();
+        configureDriveMotor();
+        initializeTurnOffset();
     }
 
     private void configureCANcoder() {


### PR DESCRIPTION
Fixes immediate robot drift by ensuring turn encoder conversion factors are set before zeroing.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b2ac560-6e7c-4542-8cdd-7d4c22d84bc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b2ac560-6e7c-4542-8cdd-7d4c22d84bc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

